### PR TITLE
Changed calls to os.walk for 2.6 compatibility.

### DIFF
--- a/pathtools/path.py
+++ b/pathtools/path.py
@@ -73,7 +73,7 @@ def get_dir_walker(recursive, topdown=True, followlinks=False):
             try:
                 yield next(os.walk(path, topdown=topdown, followlinks=followlinks))
             except NameError:
-                yield os.walk(path, topdown=topdown, followlinks=).next() #IGNORE:E1101
+                yield os.walk(path, topdown=topdown, followlinks=followlinks).next() #IGNORE:E1101
     return walk
 
 


### PR DESCRIPTION
The signature of os.walk changed between [2.5](http://docs.python.org/release/2.5/lib/os-file-dir.html) and [2.6](http://docs.python.org/release/2.6/library/os.html?highlight=walk#os.walk). This change should work in both versions.
