### PR TITLE
setup.py: replace setuptools with distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 
 import os
 import imp
-from setuptools import setup
+from distutils.core import setup
 
 PKG_DIR = 'pathtools'
 version = imp.load_source('version',


### PR DESCRIPTION
This should make installing pathtools easier in cases where neither setuptools nor distribute are installed.
