### PR TITLE
Use https url for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/source/_themes"]
 	path = docs/source/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git


### PR DESCRIPTION
Work around for cloning via git protocol. Cloning from within corporate networks that drop connections over port 22 would fail otherwise.