### PR TITLE
Update flash-sphinx-themes submodule to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/source/_themes"]
 	path = docs/source/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes.git


### PR DESCRIPTION
The use of git protocol in the flash-sphinx-themes submodule makes cloning this repo difficult for people behind strict corporate proxies that only permit outgoing traffic to ports 80 and 443. While these unlucky souls can work around this—as many currently do—by adding the following rewrite rule to their gitconfig:

    git config --global url.https://github.com/.insteadOf git://github.com/

it's usually best to avoid prefixing submodule URLs with 'git://' unless there is absolutely no other choice, because doing so can cause cryptic errors—especially in the case of projects including *other* projects that transitively include this one as a submodule. As an example, a colleague recently typed the following command on a machine behind our employer's HTTP proxy:

    git clone --recursive https://github.com/ycm-core/YouCompleteMe.git

and was greeted with the following error:

    Cloning into '/home/evadeflow/projects/YouCompleteMe/third_party/ycmd/third_party/watchdog_deps/pathtools/docs/source/_themes'...
    fatal: unable to look up github.com (port 9418) (Name or service not known)
    fatal: clone of 'git://github.com/mitsuhiko/flask-sphinx-themes.git' into submodule path '/home/evadeflow/projects/YouCompleteMe/third_party/ycmd/
    third_party/watchdog_deps/pathtools/docs/source/_themes' failed
    Failed to clone 'docs/source/_themes'. Retry scheduled
    Cloning into '/home/evadeflow/projects/YouCompleteMe/third_party/ycmd/third_party/watchdog_deps/pathtools/docs/source/_themes'...
    fatal: unable to look up github.com (port 9418) (Name or service not known)
    fatal: clone of 'git://github.com/mitsuhiko/flask-sphinx-themes.git' into submodule path '/home/evadeflow/projects/YouCompleteMe/third_party/ycmd/
    third_party/watchdog_deps/pathtools/docs/source/_themes' failed
    Failed to clone 'docs/source/_themes' a second time, aborting

While it only took me about 15 minutes to figure out and solve by adding a rewrite rule to my colleague's gitconfig, developer's less familiar with git might not fare so well, so... every time I see a project that includes a submodule via 'git://', I submit a pull request to the owner to make things a bit easier for them.