### PR TITLE
Python 3.12.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,25 @@
 # THE SOFTWARE.
 
 import os
-import imp
+import importlib.util
+import importlib.machinery
 from distutils.core import setup
 
 PKG_DIR = 'pathtools'
-version = imp.load_source('version',
-                          os.path.join(PKG_DIR, 'version.py'))
+
+# From: https://docs.python.org/3.12/whatsnew/3.12.html#removed
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+version = load_source('version',
+                      os.path.join(PKG_DIR, 'version.py'))
 
 def read_file(filename):
     """


### PR DESCRIPTION
The imp module has been removed in python 3.12.0.

From: https://docs.python.org/3.12/whatsnew/3.12.html#removed, follow the instructions to add the load_source method back into setup.py.